### PR TITLE
Fix a bug related to type conversion from schema to Java

### DIFF
--- a/helpers/complexReturnType.js
+++ b/helpers/complexReturnType.js
@@ -3,12 +3,12 @@ const typeConvert = require("./typeConvert");
 const complexReturnType = (responseSchema) => { 
     const responseType = typeConvert(responseSchema);
     switch (responseType) {
-        case "bool":
+        case "boolean":
         case "int":
         case "long":
         case "float":
         case "double":
-        case "string":
+        case "String":
             return false;
         case "Date":
         default:

--- a/helpers/createReturnStatement.js
+++ b/helpers/createReturnStatement.js
@@ -15,7 +15,7 @@ const createReturnStatement = (responseSchema) => {
   let mapperStatements = "";
   let returnStatement;
   switch (responseType) {
-    case "bool":
+    case "boolean":
     case "int":
     case "long":
     case "float":
@@ -23,7 +23,7 @@ const createReturnStatement = (responseSchema) => {
     case "Date":
       returnStatement = `${responseType}.Parse(responseBody)`;
       break;
-    case "string":
+    case "String":
       returnStatement = "responseBody";
       break;
     default:


### PR DESCRIPTION
- `String` type was previously recognised as `string which breaks the deserilation process.
- Also fix `boolean` type.