### PR TITLE
Model split fix via java parser

### DIFF
--- a/postProcessModel.js
+++ b/postProcessModel.js
@@ -1,0 +1,52 @@
+const fs = require("fs");
+const { parse } = require("java-parser");
+
+// Temporary fix
+module.exports = (folder) => {
+  model_file = folder + "/ApiModel.java";
+  try {
+    const data = fs.readFileSync(model_file, "utf8");
+    // parse java file
+    const cst = parse(data);
+
+    class_prefix = "";
+
+    // extract package statement
+    package_declaration =
+      cst.children.ordinaryCompilationUnit[0].children.packageDeclaration[0];
+    package_start = package_declaration.location.startOffset;
+    package_end = package_declaration.location.endOffset;
+
+    class_prefix += data.substring(package_start, package_end + 1) + "\n";
+
+    // extract import statements
+    import_declaration =
+      cst.children.ordinaryCompilationUnit[0].children.importDeclaration;
+    import_start = import_declaration[0].location.startOffset;
+    import_end =
+      import_declaration[import_declaration.length - 1].location.endOffset;
+
+    class_prefix += data.substring(import_start, import_end + 1) + "\n";
+
+    // process each class individually
+    cst.children.ordinaryCompilationUnit[0].children.typeDeclaration.forEach(
+      (cls) => {
+        class_name =
+          cls.children.classDeclaration[0].children.normalClassDeclaration[0]
+            .children.typeIdentifier[0].children.Identifier[0].image;
+        class_start = cls.location.startOffset;
+        class_end = cls.location.endOffset;
+        // make the inner class public as well
+        class_txt =
+          class_prefix +
+          " public " +
+          data.substring(class_start, class_end + 1) +
+          "\n";
+        fs.writeFileSync(folder + "/" + class_name + ".java", class_txt);
+      }
+    );
+    fs.rmSync(model_file);
+  } catch (err) {
+    console.log(err);
+  }
+};


### PR DESCRIPTION
Placeholder PR for model split logic via java parser. Requires changes to be called at `postProcess` stage after #14 is merged with java-parser dependency.

---

Edit and clarification: 

Initially, this PR has been proposed becuase `ApiModel` model classes are generated in one single java file and this limits the visibility of the generated model classes to package visible. 

The way this PR operates is that it uses `java-parser` in node space on top of the initially generated code to alter/manipulate the generated model classes. 

However, after #14 is merged, we#ve come to the conclusion that the class visibility was not an actual immediate issue for the generated code.

So, we don't require the model api classes to be in separate java files with public visibility, at least not yet. However, this procedure might still be necessary for future work to be carried so, the consensus was to leave this work in this PR without merging.

