### PR TITLE
feat: add @NotNull annotation on model fields if required in schema

### DIFF
--- a/helpers/isPropertyRequired.js
+++ b/helpers/isPropertyRequired.js
@@ -1,0 +1,4 @@
+const isPropertyRequired = (propertyKey, requiredList = []) =>
+  requiredList.includes(propertyKey);
+
+module.exports = isPropertyRequired;

--- a/partials/model.handlebars
+++ b/partials/model.handlebars
@@ -5,6 +5,7 @@
     {{/if}}
     class {{toClassName @key}} 
     {
+      {{setVar "requiredProperties" required}}
       {{#each properties}}
 
         {{#if description}}
@@ -16,6 +17,9 @@
         // <example>
         // {{example}}
         // <example>
+        {{/if}}
+        {{#if (isPropertyRequired @key @root.requiredProperties) }}
+        @NotNull
         {{/if}}
         public {{{safeTypeConvert this}}} {{@key}};
         

--- a/template/ApiModel.java.handlebars
+++ b/template/ApiModel.java.handlebars
@@ -2,6 +2,7 @@ package {{_options.[generator.package]}};
 
 import java.util.Date;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 {{#each components.schemas}}
 {{> model}}


### PR DESCRIPTION
In the model.feature, we have the following types of step definition:

```
And ObjectResponse should have a required property named id of type number
And ObjectResponse should have an optional property named value of type string
```

There's not really a meaningful way to indicate this in Java. In this PR, we've added the `@NotNull` annotation to all required model properties. However, this is documentation only and does not enforce anything about how the class is used.

These objects are currently created by deserialising JSON.

In the C# generator, required/optional properties are indicated by using "int" or "int?" types.

Alternative options include:
1. Not making a distinction at all, and ignoring these step definitions.
2. Using Optionals.
3. Using "final".
4. Inspecting constructors to see whether it is possible for fields not to be set