### PR TITLE
Fix: adjust query bodies with empty/null depending on query type

### DIFF
--- a/helpers/queryType.js
+++ b/helpers/queryType.js
@@ -1,11 +1,11 @@
 const queryType = (httpVerb) => {
-    // For GET and HEAD requests return `null` body since okttp doesn't like empty requests.
-    let body = "null";
-    if (httpVerb != "get" && httpVerb != "head") {
-        // For other requests such as PUT or POST if the body is empty `null` is not a valid body.
-        body = `RequestBody.create("", null)`;
-    }
-    return `.method("${httpVerb.toUpperCase()}", ${body})`;
-}
+  // For GET and HEAD requests return `null` body since okttp doesn't like empty requests.
+  let body = "null";
+  if (httpVerb != "get" && httpVerb != "head") {
+    // For other requests such as PUT or POST if the body is empty `null` is not a valid body.
+    body = `RequestBody.create("", null)`;
+  }
+  return `.method("${httpVerb.toUpperCase()}", ${body})`;
+};
 
 module.exports = queryType;

--- a/helpers/queryType.js
+++ b/helpers/queryType.js
@@ -1,3 +1,11 @@
-const queryType = (httpVerb) => `.method("${httpVerb.toUpperCase()}", null)`;
+const queryType = (httpVerb) => {
+    // For GET and HEAD requests return `null` body since okttp doesn't like empty requests.
+    let body = "null";
+    if (httpVerb != "get" && httpVerb != "head") {
+        // For other requests such as PUT or POST if the body is empty `null` is not a valid body.
+        body = `RequestBody.create("", null)`;
+    }
+    return `.method("${httpVerb.toUpperCase()}", ${body})`;
+}
 
 module.exports = queryType;


### PR DESCRIPTION
This PR fixes some of unexpected behaviour of okhttp requests without bodies.

Okhttp does not like get/head requests with empty bodies (i.e. even empty constructed bodies via `RequestBody.create("", null)`) and expects `null` while `null` is not valid for post/put etc. This PR gives the necessary body information depending on the query type. 

This PR **does not answer** the get requests with bodies issue.