### PR TITLE
chore: only make required values primitives

### DIFF
--- a/helpers/createQueryStringSnippet.js
+++ b/helpers/createQueryStringSnippet.js
@@ -36,11 +36,13 @@ const serialiseObjectParam = (param) => {
     let optional_amp = serialisedObject.length == 0 ? "" : `"&"+`;
     // open first parantheses for the conditional to make it easy to read
     // open second parantheses for making sure to combine the string in a conditional block
-    let serialisedParam =
-      `(` +
-      `${safeParamName}.${propName} == null ? "" : (` +
-      optional_amp +
-      `"${propName}="`;
+    let nullCheck;
+    if (param.required) {
+      nullCheck = "(";
+    } else {
+      nullCheck = `${safeParamName}.${propName} == null ? "" : (`;
+    }
+    let serialisedParam = `(` + nullCheck + optional_amp + `"${propName}="`;
     let suffix = isStringType(objProp)
       ? `+ java.net.URLEncoder.encode(${safeParamName}.${propName}, StandardCharsets.UTF_8)`
       : `+ ${safeParamName}.${propName}`;

--- a/partials/model.handlebars
+++ b/partials/model.handlebars
@@ -17,11 +17,17 @@
         // {{example}}
         // <example>
         {{/if}}
-        public {{{safeTypeConvert this}}} {{@key}};
-        
-        public {{{safeTypeConvert this}}} get{{toParamNameCapital @key}}() { return {{@key}}; }
+        {{#ifContains ../required @key}}
+        {{setVar "shouldBox" false}}
+        {{else}}
+        {{setVar "shouldBox" true}}
+        {{/ifContains}}
 
-        public void set{{toParamNameCapital @key}}({{{safeTypeConvert this}}} new{{toParamNameCapital @key}}) { {{@key}} = new{{toParamNameCapital @key}}; }
+        public {{{safeTypeConvert this @root.shouldBox}}} {{@key}};
+        
+        public {{{safeTypeConvert this @root.shouldBox}}} get{{toParamNameCapital @key}}() { return {{@key}}; }
+
+        public void set{{toParamNameCapital @key}}({{{safeTypeConvert this @root.shouldBox}}} new{{toParamNameCapital @key}}) { {{@key}} = new{{toParamNameCapital @key}}; }
       {{/each}}
     }
     

--- a/template/ApiClient.java.handlebars
+++ b/template/ApiClient.java.handlebars
@@ -47,7 +47,11 @@ public class ApiClient{{_tag.name}} implements IApiClient{{_tag.name}} {
     {{/each}}
     public HttpResponse<{{safeTypeConvert _response.schema true}}> {{operationId}}(
         {{~#each _sortedParameters ~}}
-            {{~safeTypeConvert schema}} {{toParamName name ~}}
+            {{#ifEquals _response.required true}}
+                {{~safeTypeConvert schema false}} {{toParamName name ~}}
+            {{else}}
+                {{~safeTypeConvert schema true}} {{toParamName name ~}}
+            {{/ifEquals}}
             {{~#unless @last}}, {{/unless ~}}
         {{~/each ~}}
     ) throws IOException{{#if (bodyParameterExists _sortedParameters)}}, JsonProcessingException{{/if}}{{#if (complexReturnType _response.schema)}}, JsonMappingException{{/if}}

--- a/template/IApiClient.java.handlebars
+++ b/template/IApiClient.java.handlebars
@@ -38,7 +38,11 @@ import java.time.LocalDate;
       {{/each}}
     public HttpResponse<{{safeTypeConvert _response.schema true}}> {{operationId}}(
         {{~#each _sortedParameters ~}}
-            {{~safeTypeConvert schema}} {{toParamName name ~}}
+            {{#ifEquals _response.required true}}
+                {{~safeTypeConvert schema false}} {{toParamName name ~}}
+            {{else}}
+                {{~safeTypeConvert schema true}} {{toParamName name ~}}
+            {{/ifEquals}}
             {{~#unless @last}}, {{/unless ~}}
         {{~/each ~}}
     ) throws {{#if (pathContentTypeSupported this)}}IOException{{#if (bodyParameterExists _sortedParameters)}}, JsonProcessingException{{/if}}{{#if (complexReturnType _response.schema)}}, JsonMappingException{{/if}}{{else}}UnsupportedOperationException{{/if}};


### PR DESCRIPTION
This fixes compile errors for all tests. Some fields were primitives when they should've been boxed. However, we now get this error:

> Error:  Calling API methods with default values  Time elapsed: 3.146 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: array contents differ at index [1], expected: <paramThree=56> but was: <paramThree=56.0>

This is because `new Double(56)` becomes `56.0`.

Will fix this in another PR.