### PR TITLE
Fix required field access in _sortedParams

### DIFF
--- a/template/ApiClient.java.handlebars
+++ b/template/ApiClient.java.handlebars
@@ -48,7 +48,7 @@ public class ApiClient{{_tag.name}} implements IApiClient{{_tag.name}} {
     {{/each}}
     public HttpResponse<{{safeTypeConvert _response.schema true}}> {{operationId}}(
         {{~#each _sortedParameters ~}}
-            {{#ifEquals _response.required true}}
+            {{#ifEquals required true}}
                 {{~safeTypeConvert schema false}} {{toParamName name ~}}
             {{else}}
                 {{~safeTypeConvert schema true}} {{toParamName name ~}}

--- a/template/IApiClient.java.handlebars
+++ b/template/IApiClient.java.handlebars
@@ -38,7 +38,7 @@ import java.time.LocalDate;
       {{/each}}
     public HttpResponse<{{safeTypeConvert _response.schema true}}> {{operationId}}(
         {{~#each _sortedParameters ~}}
-            {{#ifEquals _response.required true}}
+            {{#ifEquals required true}}
                 {{~safeTypeConvert schema false}} {{toParamName name ~}}
             {{else}}
                 {{~safeTypeConvert schema true}} {{toParamName name ~}}


### PR DESCRIPTION
Currently in the main branch, primitive making mechanism uses `_response.required` field in the internal `_sortedParameters` by 
```
{{~#each _sortedParameters ~}}
    {{#ifEquals _response.required true}}
...
```

However, the internal field doesn't necessarily have a _response field generated from the main forge. To fix this, We can look at the `required` field inside the sortedParameters.

---

An example internal `_sortedParams` field from the petstore:

```json
"_sortedParameters": [
          {
            "name": "petId",
            "in": "path",
            "description": "ID of pet that needs to be updated",
            "required": true,
            "schema": {
              "type": "integer",
              "format": "int64"
            },
            "_style": "simple",
            "_explode": false
          },
        "_response": null,
        "_tag": {
          "name": "Pet"
        } ]
```

Before this PR, the `petId` field was getting generated as optional (boxed object). With the fix, it has become required as a primitive.
