### PR TITLE
New Feature: required object annotations for boxed types

### DIFF
--- a/features/src/test/java/com/openapi/forge/StepDefinitions.java
+++ b/features/src/test/java/com/openapi/forge/StepDefinitions.java
@@ -19,7 +19,8 @@ public class StepDefinitions {
   private MethodCallHandler methodCallHandler = new MethodCallHandler(
     new TypeConverter()
   );
-  private final JavaTypeToGenericType javaTypeToGenericType = new JavaTypeToGenericType();
+  private final JavaTypeToGenericType javaTypeToGenericType =
+    new JavaTypeToGenericType();
   private Object relevantPartOfResponse;
 
   @When("calling the method {word} and the server responds with")

--- a/features/src/test/java/com/openapi/forge/StepDefinitions.java
+++ b/features/src/test/java/com/openapi/forge/StepDefinitions.java
@@ -19,8 +19,7 @@ public class StepDefinitions {
   private MethodCallHandler methodCallHandler = new MethodCallHandler(
     new TypeConverter()
   );
-  private final JavaTypeToGenericType javaTypeToGenericType =
-    new JavaTypeToGenericType();
+  private final JavaTypeToGenericType javaTypeToGenericType = new JavaTypeToGenericType();
   private Object relevantPartOfResponse;
 
   @When("calling the method {word} and the server responds with")

--- a/helpers/safeTypeConvert.js
+++ b/helpers/safeTypeConvert.js
@@ -1,11 +1,14 @@
 const Handlebars = require("handlebars");
 const typeConvert = require("./typeConvert");
 
-const safeTypeConvert = (prop, shouldBox = false) => {
+const safeTypeConvert = (prop, shouldBox = false, inDeclaration = false) => {
   if (typeof shouldBox !== "boolean") {
     shouldBox = false;
   }
-  return new Handlebars.SafeString(typeConvert(prop, shouldBox));
+  if (typeof inDeclaration !== "boolean") {
+    inDeclaration = false;
+  }
+  return new Handlebars.SafeString(typeConvert(prop, shouldBox, inDeclaration));
 };
 
 module.exports = safeTypeConvert;

--- a/helpers/safeTypeConvert.js
+++ b/helpers/safeTypeConvert.js
@@ -1,9 +1,6 @@
 const Handlebars = require("handlebars");
 const typeConvert = require("./typeConvert");
 
-// If safeTypeConvert is called without the optional arguments, these arguments defaults to false
-// For inFnSignature, this variant should be only called in function definitions to provide necessary
-//  necessary annotations for the public api.
 const safeTypeConvert = (prop, shouldBox = false, inFnSignature = false) => {
   if (typeof shouldBox !== "boolean") {
     shouldBox = false;

--- a/helpers/safeTypeConvert.js
+++ b/helpers/safeTypeConvert.js
@@ -1,14 +1,17 @@
 const Handlebars = require("handlebars");
 const typeConvert = require("./typeConvert");
 
-const safeTypeConvert = (prop, shouldBox = false, inDeclaration = false) => {
+// If safeTypeConvert is called without the optional arguments, these arguments defaults to false
+// For inFnSignature, this variant should be only called in function definitions to provide necessary
+//  necessary annotations for the public api.
+const safeTypeConvert = (prop, shouldBox = false, inFnSignature = false) => {
   if (typeof shouldBox !== "boolean") {
     shouldBox = false;
   }
-  if (typeof inDeclaration !== "boolean") {
-    inDeclaration = false;
+  if (typeof inFnSignature !== "boolean") {
+    inFnSignature = false;
   }
-  return new Handlebars.SafeString(typeConvert(prop, shouldBox, inDeclaration));
+  return new Handlebars.SafeString(typeConvert(prop, shouldBox, inFnSignature));
 };
 
 module.exports = safeTypeConvert;

--- a/helpers/typeConvert.js
+++ b/helpers/typeConvert.js
@@ -1,6 +1,7 @@
 const toSafeName = require("./toClassName");
 
-const fromFormat = (propFormat, shouldBox) => {
+const fromFormat = (propFormat, shouldBox, inDeclaration) => {
+  let required_object_prefix = !shouldBox && inDeclaration ? "@NonNull " : "";
   switch (propFormat) {
     case "int32":
       return shouldBox ? "Integer" : "int";
@@ -11,19 +12,26 @@ const fromFormat = (propFormat, shouldBox) => {
     case "double":
       return shouldBox ? "Double" : "double";
     case "date":
-      return "LocalDate";
+      return required_object_prefix + "LocalDate";
     case "date-time":
-      return "ZonedDateTime";
+      return required_object_prefix + "ZonedDateTime";
     case "byte":
     case "binary":
     case "string":
-      return "String";
+      return required_object_prefix + "String";
     default:
       return shouldBox ? "Void" : "void";
   }
 };
 
-const fromType = (propType, additionalProperties, items, shouldBox) => {
+const fromType = (
+  propType,
+  additionalProperties,
+  items,
+  shouldBox,
+  inDeclaration
+) => {
+  let required_object_prefix = !shouldBox && inDeclaration ? "@NonNull " : "";
   switch (propType) {
     case "integer":
       return shouldBox ? "Integer" : "int";
@@ -32,7 +40,7 @@ const fromType = (propType, additionalProperties, items, shouldBox) => {
     case "boolean":
       return shouldBox ? "Boolean" : "boolean";
     case "string":
-      return "String";
+      return required_object_prefix + "String";
     case "array":
       return `List<${typeConvert(items, true)}>`;
     // inline object definition
@@ -40,26 +48,33 @@ const fromType = (propType, additionalProperties, items, shouldBox) => {
       if (additionalProperties) {
         return `HashMap<String,${typeConvert(additionalProperties, true)}>`;
       } else {
-        return "Object";
+        return required_object_prefix + "Object";
       }
     default:
       return shouldBox ? "Void" : "void";
   }
 };
 
-const typeConvert = (prop, shouldBox = false) => {
+const typeConvert = (prop, shouldBox = false, inDeclaration = false) => {
   if (prop === null) return shouldBox ? "Void" : "void";
 
-  if (prop === undefined) return "object";
+  if (prop === undefined) return "Object";
 
   // resolve references
   if (prop.$ref) {
-    return toSafeName(prop.$ref.split("/").pop());
+    let required_object_prefix = !shouldBox && inDeclaration ? "@NonNull " : "";
+    return required_object_prefix + toSafeName(prop.$ref.split("/").pop());
   }
 
   const type = prop.format
-    ? fromFormat(prop.format, shouldBox)
-    : fromType(prop.type, prop.additionalProperties, prop.items, shouldBox);
+    ? fromFormat(prop.format, shouldBox, inDeclaration)
+    : fromType(
+        prop.type,
+        prop.additionalProperties,
+        prop.items,
+        shouldBox,
+        inDeclaration
+      );
 
   return type === "" ? "object" : type;
 };

--- a/helpers/typeConvert.js
+++ b/helpers/typeConvert.js
@@ -1,7 +1,7 @@
 const toSafeName = require("./toClassName");
 
 const fromFormat = (propFormat, shouldBox, inFnSignature) => {
-  const notNullPrefix  = !shouldBox && inFnSignature ? "@NonNull " : "";
+  const notNullPrefix = !shouldBox && inFnSignature ? "@NonNull " : "";
   switch (propFormat) {
     case "int32":
       return shouldBox ? "Integer" : "int";
@@ -12,13 +12,13 @@ const fromFormat = (propFormat, shouldBox, inFnSignature) => {
     case "double":
       return shouldBox ? "Double" : "double";
     case "date":
-      return notNullPrefix  + "LocalDate";
+      return notNullPrefix + "LocalDate";
     case "date-time":
-      return notNullPrefix  + "ZonedDateTime";
+      return notNullPrefix + "ZonedDateTime";
     case "byte":
     case "binary":
     case "string":
-      return notNullPrefix  + "String";
+      return notNullPrefix + "String";
     default:
       return shouldBox ? "Void" : "void";
   }
@@ -31,7 +31,7 @@ const fromType = (
   shouldBox,
   inFnSignature
 ) => {
-  const notNullPrefix  = !shouldBox && inFnSignature ? "@NonNull " : "";
+  const notNullPrefix = !shouldBox && inFnSignature ? "@NonNull " : "";
   switch (propType) {
     case "integer":
       return shouldBox ? "Integer" : "int";
@@ -40,7 +40,7 @@ const fromType = (
     case "boolean":
       return shouldBox ? "Boolean" : "boolean";
     case "string":
-      return notNullPrefix  + "String";
+      return notNullPrefix + "String";
     case "array":
       return `List<${typeConvert(items, true)}>`;
     // inline object definition
@@ -48,7 +48,7 @@ const fromType = (
       if (additionalProperties) {
         return `HashMap<String,${typeConvert(additionalProperties, true)}>`;
       } else {
-        return notNullPrefix  + "Object";
+        return notNullPrefix + "Object";
       }
     default:
       return shouldBox ? "Void" : "void";
@@ -62,8 +62,8 @@ const typeConvert = (prop, shouldBox = false, inFnSignature = false) => {
 
   // resolve references
   if (prop.$ref) {
-    const notNullPrefix  = !shouldBox && inFnSignature ? "@NonNull " : "";
-    return notNullPrefix  + toSafeName(prop.$ref.split("/").pop());
+    const notNullPrefix = !shouldBox && inFnSignature ? "@NonNull " : "";
+    return notNullPrefix + toSafeName(prop.$ref.split("/").pop());
   }
 
   const type = prop.format

--- a/helpers/typeConvert.js
+++ b/helpers/typeConvert.js
@@ -1,7 +1,7 @@
 const toSafeName = require("./toClassName");
 
 const fromFormat = (propFormat, shouldBox, inFnSignature) => {
-  let required_object_prefix = !shouldBox && inFnSignature ? "@NonNull " : "";
+  const required_object_prefix = !shouldBox && inFnSignature ? "@NonNull " : "";
   switch (propFormat) {
     case "int32":
       return shouldBox ? "Integer" : "int";
@@ -31,7 +31,7 @@ const fromType = (
   shouldBox,
   inFnSignature
 ) => {
-  let required_object_prefix = !shouldBox && inFnSignature ? "@NonNull " : "";
+  const required_object_prefix = !shouldBox && inFnSignature ? "@NonNull " : "";
   switch (propType) {
     case "integer":
       return shouldBox ? "Integer" : "int";

--- a/helpers/typeConvert.js
+++ b/helpers/typeConvert.js
@@ -1,7 +1,7 @@
 const toSafeName = require("./toClassName");
 
 const fromFormat = (propFormat, shouldBox, inFnSignature) => {
-  const required_object_prefix = !shouldBox && inFnSignature ? "@NonNull " : "";
+  const notNullPrefix  = !shouldBox && inFnSignature ? "@NonNull " : "";
   switch (propFormat) {
     case "int32":
       return shouldBox ? "Integer" : "int";
@@ -12,13 +12,13 @@ const fromFormat = (propFormat, shouldBox, inFnSignature) => {
     case "double":
       return shouldBox ? "Double" : "double";
     case "date":
-      return required_object_prefix + "LocalDate";
+      return notNullPrefix  + "LocalDate";
     case "date-time":
-      return required_object_prefix + "ZonedDateTime";
+      return notNullPrefix  + "ZonedDateTime";
     case "byte":
     case "binary":
     case "string":
-      return required_object_prefix + "String";
+      return notNullPrefix  + "String";
     default:
       return shouldBox ? "Void" : "void";
   }
@@ -31,7 +31,7 @@ const fromType = (
   shouldBox,
   inFnSignature
 ) => {
-  const required_object_prefix = !shouldBox && inFnSignature ? "@NonNull " : "";
+  const notNullPrefix  = !shouldBox && inFnSignature ? "@NonNull " : "";
   switch (propType) {
     case "integer":
       return shouldBox ? "Integer" : "int";
@@ -40,7 +40,7 @@ const fromType = (
     case "boolean":
       return shouldBox ? "Boolean" : "boolean";
     case "string":
-      return required_object_prefix + "String";
+      return notNullPrefix  + "String";
     case "array":
       return `List<${typeConvert(items, true)}>`;
     // inline object definition
@@ -48,7 +48,7 @@ const fromType = (
       if (additionalProperties) {
         return `HashMap<String,${typeConvert(additionalProperties, true)}>`;
       } else {
-        return required_object_prefix + "Object";
+        return notNullPrefix  + "Object";
       }
     default:
       return shouldBox ? "Void" : "void";
@@ -62,8 +62,8 @@ const typeConvert = (prop, shouldBox = false, inFnSignature = false) => {
 
   // resolve references
   if (prop.$ref) {
-    let required_object_prefix = !shouldBox && inFnSignature ? "@NonNull " : "";
-    return required_object_prefix + toSafeName(prop.$ref.split("/").pop());
+    const notNullPrefix  = !shouldBox && inFnSignature ? "@NonNull " : "";
+    return notNullPrefix  + toSafeName(prop.$ref.split("/").pop());
   }
 
   const type = prop.format

--- a/helpers/typeConvert.js
+++ b/helpers/typeConvert.js
@@ -1,7 +1,7 @@
 const toSafeName = require("./toClassName");
 
-const fromFormat = (propFormat, shouldBox, inDeclaration) => {
-  let required_object_prefix = !shouldBox && inDeclaration ? "@NonNull " : "";
+const fromFormat = (propFormat, shouldBox, inFnSignature) => {
+  let required_object_prefix = !shouldBox && inFnSignature ? "@NonNull " : "";
   switch (propFormat) {
     case "int32":
       return shouldBox ? "Integer" : "int";
@@ -29,9 +29,9 @@ const fromType = (
   additionalProperties,
   items,
   shouldBox,
-  inDeclaration
+  inFnSignature
 ) => {
-  let required_object_prefix = !shouldBox && inDeclaration ? "@NonNull " : "";
+  let required_object_prefix = !shouldBox && inFnSignature ? "@NonNull " : "";
   switch (propType) {
     case "integer":
       return shouldBox ? "Integer" : "int";
@@ -55,25 +55,25 @@ const fromType = (
   }
 };
 
-const typeConvert = (prop, shouldBox = false, inDeclaration = false) => {
+const typeConvert = (prop, shouldBox = false, inFnSignature = false) => {
   if (prop === null) return shouldBox ? "Void" : "void";
 
   if (prop === undefined) return "Object";
 
   // resolve references
   if (prop.$ref) {
-    let required_object_prefix = !shouldBox && inDeclaration ? "@NonNull " : "";
+    let required_object_prefix = !shouldBox && inFnSignature ? "@NonNull " : "";
     return required_object_prefix + toSafeName(prop.$ref.split("/").pop());
   }
 
   const type = prop.format
-    ? fromFormat(prop.format, shouldBox, inDeclaration)
+    ? fromFormat(prop.format, shouldBox, inFnSignature)
     : fromType(
         prop.type,
         prop.additionalProperties,
         prop.items,
         shouldBox,
-        inDeclaration
+        inFnSignature
       );
 
   return type === "" ? "object" : type;

--- a/template/ApiClient.java.handlebars
+++ b/template/ApiClient.java.handlebars
@@ -99,7 +99,16 @@ public class ApiClient{{_tag.name}} implements IApiClient{{_tag.name}} {
         );
     }
     {{else}}
-    public {{#if _response.schema}}HttpResponse<{{safeTypeConvert _response.schema true}}>{{/if}} {{operationId}}({{#each _sortedParameters}}{{safeTypeConvert schema}} {{name}}{{#if schema.default}} = {{{quoteIfString schema.default}}}{{/if}}{{#unless @last}}, {{/unless}}{{/each}}) throws UnsupportedOperationException
+    public {{#if _response.schema}}HttpResponse<{{safeTypeConvert _response.schema true}}>{{/if}} {{operationId}}(
+        {{~#each _sortedParameters ~}}
+            {{#ifEquals _response.required true}}
+                {{~safeTypeConvert schema false true}} {{toParamName name ~}}
+            {{else}}
+                {{~safeTypeConvert schema true true}} {{toParamName name ~}}
+            {{/ifEquals}}
+            {{~#unless @last}}, {{/unless ~}}
+        {{~/each ~}}
+     ) throws UnsupportedOperationException
     {
         throw new UnsupportedOperationException("Operation 'uploadFile' most likely does not support json encoded requests which are not supported by openapi forge.");
     }    

--- a/template/ApiClient.java.handlebars
+++ b/template/ApiClient.java.handlebars
@@ -84,7 +84,7 @@ public class ApiClient{{_tag.name}} implements IApiClient{{_tag.name}} {
             .build();
         Call call = _client.newCall(request);
         Response response = call.execute();
-        {{safeTypeConvert _response.schema true true}} responseObject;
+        {{safeTypeConvert _response.schema true}} responseObject;
         {{#if _response.schema}}
         String responseBodyString = response.body().string();
         {{createReturnStatement _response.schema}}

--- a/template/ApiClient.java.handlebars
+++ b/template/ApiClient.java.handlebars
@@ -50,7 +50,7 @@ public class ApiClient{{_tag.name}} implements IApiClient{{_tag.name}} {
     {{/each}}
     public HttpResponse<{{safeTypeConvert _response.schema true}}> {{operationId}}(
         {{~#each _sortedParameters ~}}
-            {{#ifEquals _response.required true}}
+            {{#ifEquals required true}}
                 {{~safeTypeConvert schema false true}} {{toParamName name ~}}
             {{else}}
                 {{~safeTypeConvert schema true true}} {{toParamName name ~}}

--- a/template/ApiClient.java.handlebars
+++ b/template/ApiClient.java.handlebars
@@ -101,7 +101,7 @@ public class ApiClient{{_tag.name}} implements IApiClient{{_tag.name}} {
     {{else}}
     public {{#if _response.schema}}HttpResponse<{{safeTypeConvert _response.schema true}}>{{/if}} {{operationId}}(
         {{~#each _sortedParameters ~}}
-            {{#ifEquals _response.required true}}
+            {{#ifEquals required true}}
                 {{~safeTypeConvert schema false true}} {{toParamName name ~}}
             {{else}}
                 {{~safeTypeConvert schema true true}} {{toParamName name ~}}

--- a/template/ApiClient.java.handlebars
+++ b/template/ApiClient.java.handlebars
@@ -13,6 +13,8 @@ import okhttp3.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.springframework.lang.NonNull;
+
 
 
 
@@ -49,9 +51,9 @@ public class ApiClient{{_tag.name}} implements IApiClient{{_tag.name}} {
     public HttpResponse<{{safeTypeConvert _response.schema true}}> {{operationId}}(
         {{~#each _sortedParameters ~}}
             {{#ifEquals _response.required true}}
-                {{~safeTypeConvert schema false}} {{toParamName name ~}}
+                {{~safeTypeConvert schema false true}} {{toParamName name ~}}
             {{else}}
-                {{~safeTypeConvert schema true}} {{toParamName name ~}}
+                {{~safeTypeConvert schema true true}} {{toParamName name ~}}
             {{/ifEquals}}
             {{~#unless @last}}, {{/unless ~}}
         {{~/each ~}}
@@ -82,7 +84,7 @@ public class ApiClient{{_tag.name}} implements IApiClient{{_tag.name}} {
             .build();
         Call call = _client.newCall(request);
         Response response = call.execute();
-        {{safeTypeConvert _response.schema true}} responseObject;
+        {{safeTypeConvert _response.schema true true}} responseObject;
         {{#if _response.schema}}
         String responseBodyString = response.body().string();
         {{createReturnStatement _response.schema}}

--- a/template/IApiClient.java.handlebars
+++ b/template/IApiClient.java.handlebars
@@ -40,7 +40,7 @@ import org.springframework.lang.NonNull;
       {{/each}}
     public HttpResponse<{{safeTypeConvert _response.schema true}}> {{operationId}}(
         {{~#each _sortedParameters ~}}
-            {{#ifEquals _response.required true}}
+            {{#ifEquals required true}}
                 {{~safeTypeConvert schema false true}} {{toParamName name ~}}
             {{else}}
                 {{~safeTypeConvert schema true true}} {{toParamName name ~}}

--- a/template/IApiClient.java.handlebars
+++ b/template/IApiClient.java.handlebars
@@ -9,6 +9,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.time.ZonedDateTime;
 import java.time.LocalDate;
+import org.springframework.lang.NonNull;
+
 
 // <summary>
 // {{_info.title}}
@@ -39,9 +41,9 @@ import java.time.LocalDate;
     public HttpResponse<{{safeTypeConvert _response.schema true}}> {{operationId}}(
         {{~#each _sortedParameters ~}}
             {{#ifEquals _response.required true}}
-                {{~safeTypeConvert schema false}} {{toParamName name ~}}
+                {{~safeTypeConvert schema false true}} {{toParamName name ~}}
             {{else}}
-                {{~safeTypeConvert schema true}} {{toParamName name ~}}
+                {{~safeTypeConvert schema true true}} {{toParamName name ~}}
             {{/ifEquals}}
             {{~#unless @last}}, {{/unless ~}}
         {{~/each ~}}


### PR DESCRIPTION
This PR brings `@NonNull` annotation for required boxed type objects.

Pet store example:

```json
  ..
  "operationId": "getUserByName",
  "parameters": [
    {
      "name": "username",
      "in": "path",
      "description": "The name that needs to be fetched. Use user1 for testing. ",
      "required": true,
      "schema": {
        "type": "string"
      },
      "_style": "simple",
      "_explode": false
    }
  ..
```

becomes

```java
public HttpResponse<User> getUserByName(@NonNull String username)
```

--- 

Note: This PR uses the required fix from #70.