### PR TITLE
Chore: skip one bdd test

### DIFF
--- a/features/src/test/java/com/openapi/forge/RunCucumberTest.java
+++ b/features/src/test/java/com/openapi/forge/RunCucumberTest.java
@@ -14,7 +14,8 @@ import org.junit.platform.suite.api.Suite;
 @SelectClasspathResource("com/openapi/forge")
 @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "com.openapi.forge")
-// dont run one particular scenario with a get request with body.
+// Skip a test scenario where a non-standard behaviour of GET request with requestBody is used.
+// See discussion in https://github.com/ScottLogic/openapi-forge/issues/182.
 @ConfigurationParameter(
   key = FILTER_NAME_PROPERTY_NAME,
   value = "^(?!Calling API methods with a request body).*$"

--- a/features/src/test/java/com/openapi/forge/RunCucumberTest.java
+++ b/features/src/test/java/com/openapi/forge/RunCucumberTest.java
@@ -1,5 +1,6 @@
 package com.openapi.forge;
 
+import static io.cucumber.junit.platform.engine.Constants.FILTER_NAME_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
 
@@ -13,4 +14,9 @@ import org.junit.platform.suite.api.Suite;
 @SelectClasspathResource("com/openapi/forge")
 @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "com.openapi.forge")
+// dont run one particular scenario with a get request with body.
+@ConfigurationParameter(
+  key = FILTER_NAME_PROPERTY_NAME,
+  value = "^(?!Calling API methods with a request body).*$"
+)
 public class RunCucumberTest {}


### PR DESCRIPTION
This PR adds cucumber annotations to skip a particular scenario where there is a get request with body to make the tests run succesfully. 

Note: for a succesful run `mvn t --quiet` does not print the test statistics. Without the quiet param we can see 45 success and 1 skip.